### PR TITLE
chore: fix deprecated set-output

### DIFF
--- a/actions/maven/common.sh
+++ b/actions/maven/common.sh
@@ -101,5 +101,5 @@ function mavenProjectVersion() {
 function set_output() {
   # $1 = key
   # $2 = value
-  echo "::set-output name=${1}::${2}"
+  echo "${1}=${2}" >> $GITHUB_OUTPUT
 }


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Bob Callaway <bcallaway@google.com>